### PR TITLE
docs: link to org Discussions community hub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community Discussions
+    url: https://github.com/orgs/opendecree/discussions
+    about: Questions, ideas, and show-and-tell — ask here before filing an issue.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Runnable examples in the [`examples/`](examples/) directory:
 - Node.js 20+
 - A running OpenDecree server (v0.3.0+)
 
+## Questions?
+
+Head to [OpenDecree Discussions](https://github.com/orgs/opendecree/discussions) -- our community hub covers all OpenDecree repos.
+
 ## License
 
 Apache License 2.0 -- see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/config.yml` `contact_links` pointing to `https://github.com/orgs/opendecree/discussions`
- Add "Questions?" section to README linking the org Discussions hub

Part of opendecree/decree#167 — single community surface across all OpenDecree repos.

## Test plan
- [ ] "New issue" page shows the Community Discussions link
- [ ] README renders "Questions?" section correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)