### PR TITLE
docs: add npm downloads + repostatus alpha badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![npm](https://img.shields.io/npm/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![Node](https://img.shields.io/node/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![Downloads](https://img.shields.io/npm/dm/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
-[![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://github.com/opendecree/decree-typescript)
 [![License](https://img.shields.io/github/license/opendecree/decree-typescript)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 [![CI](https://github.com/opendecree/decree-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-typescript/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![Node](https://img.shields.io/node/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
+[![Downloads](https://img.shields.io/npm/dm/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)](https://github.com/opendecree/decree-typescript)
 [![License](https://img.shields.io/github/license/opendecree/decree-typescript)](LICENSE)
+[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 
 TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-driven configuration management.
 


### PR DESCRIPTION
## Summary
- Adds npm monthly downloads badge and [repostatus.org](https://www.repostatus.org/) **WIP** badge.
- Completes AC for decree-typescript in opendecree/decree#146.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Badges link to their targets (npm page, repostatus.org/#wip)