### PR TITLE
ci: add release.yml for categorized release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: "⚠️ Breaking Changes"
+      labels:
+        - breaking
+    - title: "Features"
+      labels:
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - bug
+    - title: "Documentation"
+      labels:
+        - docs
+        - documentation
+    - title: "Dependencies"
+      labels:
+        - dependencies
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

Adds `.github/release.yml` so `gh release create --generate-notes` (and the GitHub UI auto-generator) groups PRs by label instead of producing a flat commit list.

Categories: Breaking Changes (`breaking`), Features (`enhancement`), Bug Fixes (`bug`), Documentation (`docs`/`documentation`), Dependencies (`dependencies`), Other Changes (`*`). Excludes `duplicate`/`invalid`/`wontfix`.

Refs opendecree/decree#145.

## Test plan

- [ ] Next release auto-categorizes PRs by label.