### PR TITLE
ci: add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
+      - name: Upload coverage to Codecov
+        # codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          files: coverage/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   examples:
     name: Examples
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Downloads](https://img.shields.io/npm/dm/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![License](https://img.shields.io/github/license/opendecree/decree-typescript)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
+[![codecov](https://codecov.io/gh/opendecree/decree-typescript/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-typescript)
 
 TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-driven configuration management.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Codecov has no coverage data for the TypeScript SDK — this wires up uploads so the dashboard, PR delta comments, and badge all work
- Uploads \`coverage/coverage-final.json\` produced by the existing \`vitest run --coverage\` (v8 provider) step
- Adds \`codecov.yml\` enforcing no project regression and ≥80% patch coverage

## Test plan
- [ ] Ensure \`CODECOV_TOKEN\` is set as org-level secret (handled in opendecree/decree#409)
- [ ] Verify coverage upload lands in Codecov dashboard after merge
- [ ] Confirm badge renders in README

Refs opendecree/decree#153

🤖 Generated with [Claude Code](https://claude.com/claude-code)