### PR TITLE
fix(exports): add ./package.json subpath and document ESM-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-
 
 > **Alpha** -- This SDK is under active development. APIs and behavior may change without notice between versions.
 
+## Requirements
+
+- Node.js **≥ 20** (ESM-only package — CommonJS is not supported)
+
 ## Install
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- CJS consumers were receiving `ERR_REQUIRE_ESM` because the exports map had no `default` condition and no `./package.json` subpath.
- Staying ESM-only is the right call: Node ≥20 is already the floor, and a dual CJS build would add tsconfig/output complexity for no alpha benefit.
- Adds the `./package.json` subpath (fixes typedoc and bundlers that probe it) and a `default` fallback on the main entry so bundlers that don't honor `import` still resolve correctly.

## Test plan

- [ ] `package.json` exports map reviewed manually against Node.js conditional exports spec
- [ ] README Requirements section clearly states ESM-only with Node ≥20
- [ ] CI build + typecheck pass

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)