### PR TITLE
fix(convert): throw on int64 overflow past MAX_SAFE_INTEGER

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -31,6 +31,12 @@ export function convertValue(raw: string, type: Converter): unknown {
 		if (globalThis.Number.isNaN(n)) {
 			throw new TypeMismatchError(`cannot convert ${JSON.stringify(raw)} to number`);
 		}
+		// Integer strings that exceed safe integer range lose precision silently — reject them.
+		if (/^-?\d+$/.test(raw.trim()) && !globalThis.Number.isSafeInteger(n)) {
+			throw new TypeMismatchError(
+				`integer ${JSON.stringify(raw)} exceeds safe integer range; use BigInt`,
+			);
+		}
 		return n;
 	}
 	if (type === Boolean) {

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -38,6 +38,30 @@ describe("convertValue", () => {
 		it("throws TypeMismatchError for empty string", () => {
 			expect(() => convertValue("", Number)).toThrow(TypeMismatchError);
 		});
+
+		it("accepts Number.MAX_SAFE_INTEGER", () => {
+			expect(convertValue(String(Number.MAX_SAFE_INTEGER), Number)).toBe(Number.MAX_SAFE_INTEGER);
+		});
+
+		it("accepts Number.MIN_SAFE_INTEGER", () => {
+			expect(convertValue(String(Number.MIN_SAFE_INTEGER), Number)).toBe(Number.MIN_SAFE_INTEGER);
+		});
+
+		it("throws TypeMismatchError for integer above MAX_SAFE_INTEGER", () => {
+			expect(() => convertValue(String(Number.MAX_SAFE_INTEGER + 1), Number)).toThrow(
+				TypeMismatchError,
+			);
+		});
+
+		it("throws TypeMismatchError for integer below MIN_SAFE_INTEGER", () => {
+			expect(() => convertValue(String(Number.MIN_SAFE_INTEGER - 1), Number)).toThrow(
+				TypeMismatchError,
+			);
+		});
+
+		it("does not throw for large float (non-integer) above MAX_SAFE_INTEGER", () => {
+			expect(convertValue("1e20", Number)).toBe(1e20);
+		});
 	});
 
 	describe("Boolean converter", () => {


### PR DESCRIPTION
## Summary
- Silent precision loss in `convertValue` when integer strings exceed `Number.MAX_SAFE_INTEGER` (timestamps and IDs are at risk)
- Detects pure integer strings via regex and rejects them with `TypeMismatchError` if `Number.isSafeInteger()` is false
- Float strings like `"1e20"` are unaffected — the guard only triggers on digit-only input

## Test plan
- [x] `convertValue(String(MAX_SAFE_INTEGER), Number)` passes
- [x] `convertValue(String(MIN_SAFE_INTEGER), Number)` passes
- [x] `convertValue(String(MAX_SAFE_INTEGER + 1), Number)` throws `TypeMismatchError`
- [x] `convertValue(String(MIN_SAFE_INTEGER - 1), Number)` throws `TypeMismatchError`
- [x] `convertValue("1e20", Number)` passes (float, not integer string)
- [x] All 169 existing tests pass

Closes #50