### PR TITLE
feat(dispose): add Symbol.asyncDispose to ConfigClient and ConfigWatcher

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -353,6 +353,13 @@ export class ConfigClient {
 		this.close();
 	}
 
+	/**
+	 * Async dispose pattern support — use with `await using`.
+	 */
+	async [Symbol.asyncDispose](): Promise<void> {
+		this.close();
+	}
+
 	// --- Private helpers ---
 
 	private async fetchServerInfo(): Promise<ServerInfo> {

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -357,10 +357,17 @@ export class ConfigWatcher {
 	 * Dispose pattern support (TypeScript 5.2+).
 	 *
 	 * Calls stop() synchronously (best-effort). For full cleanup, prefer
-	 * calling `await watcher.stop()` explicitly.
+	 * `await using` or calling `await watcher.stop()` explicitly.
 	 */
 	[Symbol.dispose](): void {
 		void this.stop();
+	}
+
+	/**
+	 * Async dispose pattern support — use with `await using`.
+	 */
+	async [Symbol.asyncDispose](): Promise<void> {
+		await this.stop();
 	}
 
 	private async loadSnapshot(): Promise<void> {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -382,6 +382,23 @@ describe("ConfigClient", () => {
 		});
 	});
 
+	describe("Symbol.asyncDispose", () => {
+		it("closes both stubs and resolves", async () => {
+			await client[Symbol.asyncDispose]();
+			expect(configStub.close).toHaveBeenCalledTimes(1);
+			expect(serverStub.close).toHaveBeenCalledTimes(1);
+		});
+
+		it("works with await using", async () => {
+			await (async () => {
+				await using c = client;
+				void c;
+			})();
+			expect(configStub.close).toHaveBeenCalledTimes(1);
+			expect(serverStub.close).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe("per-call timeout", () => {
 		it("get() uses per-call timeout over client default", async () => {
 			let capturedDeadline: number | undefined;

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -484,6 +484,33 @@ describe("ConfigWatcher", () => {
 		});
 	});
 
+	describe("Symbol.asyncDispose", () => {
+		it("awaits stop() before resolving", async () => {
+			const watcher = createWatcher();
+			mockGetConfigSuccess([]);
+			watcher.field("payments.fee", Number, { default: 0.01 });
+
+			await watcher.start();
+			await watcher[Symbol.asyncDispose]();
+
+			expect(mockStream.cancel).toHaveBeenCalledOnce();
+		});
+
+		it("works with await using", async () => {
+			const watcher = createWatcher();
+			mockGetConfigSuccess([]);
+			watcher.field("payments.fee", Number, { default: 0.01 });
+			await watcher.start();
+
+			await (async () => {
+				await using w = watcher;
+				void w;
+			})();
+
+			expect(mockStream.cancel).toHaveBeenCalledOnce();
+		});
+	});
+
 	describe("processing changes", () => {
 		it("updates fields on data events", async () => {
 			const watcher = createWatcher();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "esnext.disposable"],
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
## Summary

- `Symbol.dispose` on `ConfigWatcher` calls `stop()` via fire-and-forget (`void this.stop()`), so `await using` blocks would return before cleanup completed.
- Added `Symbol.asyncDispose` to both `ConfigClient` and `ConfigWatcher` so the runtime can properly `await` the teardown path.
- Added `esnext.disposable` to `tsconfig.json` lib so the compiler recognizes the symbol without bumping the compile target.

## Test plan

- [ ] `ConfigClient[Symbol.asyncDispose]()` — closes both stubs and resolves
- [ ] `ConfigClient` with `await using` — stubs closed after block exits
- [ ] `ConfigWatcher[Symbol.asyncDispose]()` — awaits `stop()` before resolving, stream cancelled
- [ ] `ConfigWatcher` with `await using` — stream cancelled after block exits
- [ ] All 173 existing tests still pass

Closes #51