### PR TITLE
fix(client): clear serverInfoPromise on rejection to allow retry

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -100,6 +100,9 @@ export class ConfigClient {
 	get serverInfo(): Promise<ServerInfo> {
 		if (this.serverInfoPromise === undefined) {
 			this.serverInfoPromise = this.fetchServerInfo();
+			this.serverInfoPromise.catch(() => {
+				this.serverInfoPromise = undefined;
+			});
 		}
 		return this.serverInfoPromise;
 	}

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -322,6 +322,27 @@ describe("ConfigClient", () => {
 			await expect(client.serverInfo).rejects.toThrow(UnavailableError);
 		});
 
+		it("clears cached promise on rejection so callers can retry", async () => {
+			serverStub.getServerInfo
+				.mockImplementationOnce(
+					(_req: unknown, _meta: unknown, _opts: unknown, cb: (...args: unknown[]) => void) => {
+						cb(makeServiceError(status.UNAVAILABLE, "server down"));
+					},
+				)
+				.mockImplementationOnce(
+					(_req: unknown, _meta: unknown, _opts: unknown, cb: (...args: unknown[]) => void) => {
+						cb(null, { version: "0.9.0", commit: "def456", features: {} });
+					},
+				);
+
+			await expect(client.serverInfo).rejects.toThrow(UnavailableError);
+			// allow the .catch cleanup to run
+			await Promise.resolve();
+			const info = await client.serverInfo;
+			expect(info.version).toBe("0.9.0");
+			expect(serverStub.getServerInfo).toHaveBeenCalledTimes(2);
+		});
+
 		it("exposes deprecated serverVersion alias", async () => {
 			serverStub.getServerInfo.mockImplementation(
 				(_req: unknown, _meta: unknown, _opts: unknown, cb: (...args: unknown[]) => void) => {


### PR DESCRIPTION
## Summary

- Prevents `serverInfoPromise` from being poisoned on first failure — previously, a rejected promise was cached forever, making the client permanently broken after any transient error.
- The `.catch` handler now clears `serverInfoPromise` on rejection so subsequent callers get a fresh attempt.

## Test plan

- [x] Existing cache-hit test still passes (one call, same object returned)
- [x] New test: first call fails, promise clears, second call succeeds and hits the server again
- [x] All 186 tests pass

Closes #53