### PR TITLE
build: add sideEffects false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "./package.json": "./package.json"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "LICENSE",


### PR DESCRIPTION
## Summary
- Enables bundlers (webpack, rollup, esbuild) to tree-shake unused SDK exports, reducing final bundle size for consumers.
- Without this flag, bundlers must assume every module has side effects and include the entire SDK regardless of what is imported.

## Test plan
- [x] Audited all `src/` files for top-level side effects — none found (only pure `const` declarations, class/function exports)
- [x] `biome check` and `tsc --noEmit` pass
- [x] `vitest run` passes

Closes #57