### PR TITLE
feat(client): add setToken() for JWT token rotation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -430,6 +430,21 @@ export class ConfigClient {
 	}
 
 	/**
+	 * Replace the bearer token used for all subsequent RPCs (including watcher reconnects).
+	 *
+	 * Switches the client to JWT auth mode: removes any metadata-header credentials
+	 * (x-subject, x-role, x-tenant-id) that may have been set at construction time.
+	 *
+	 * @param token - Raw JWT (without the "Bearer " prefix).
+	 */
+	setToken(token: string): void {
+		this.metadata.remove("x-subject");
+		this.metadata.remove("x-role");
+		this.metadata.remove("x-tenant-id");
+		this.metadata.set("authorization", `Bearer ${token}`);
+	}
+
+	/**
 	 * Close the underlying gRPC channels.
 	 */
 	close(): void {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -828,6 +828,61 @@ describe("ConfigClient", () => {
 			});
 			tenantClient.close();
 		});
+
+		describe("setToken()", () => {
+			it("subsequent RPCs use the new Bearer token", async () => {
+				client.setToken("rotated-token");
+
+				configStub.getField.mockImplementation(
+					(_req: unknown, meta: Metadata, _opts: unknown, cb: (...args: unknown[]) => void) => {
+						expect(meta.get("authorization")).toEqual(["Bearer rotated-token"]);
+						cb(null, {
+							value: { fieldPath: "a", value: { stringValue: "v" }, checksum: "c" },
+						});
+					},
+				);
+
+				await client.get("tenant-1", "a");
+			});
+
+			it("clears metadata headers when switching from header-mode to token-mode", async () => {
+				client.setToken("jwt-abc");
+
+				configStub.getField.mockImplementation(
+					(_req: unknown, meta: Metadata, _opts: unknown, cb: (...args: unknown[]) => void) => {
+						expect(meta.get("x-subject")).toEqual([]);
+						expect(meta.get("x-role")).toEqual([]);
+						expect(meta.get("authorization")).toEqual(["Bearer jwt-abc"]);
+						cb(null, {
+							value: { fieldPath: "a", value: { stringValue: "v" }, checksum: "c" },
+						});
+					},
+				);
+
+				await client.get("tenant-1", "a");
+			});
+
+			it("rotates token on a token-mode client", async () => {
+				const tokenClient = new ConfigClient("localhost:9090", {
+					token: "initial-token",
+					retry: false,
+				});
+
+				tokenClient.setToken("refreshed-token");
+
+				configStub.getField.mockImplementation(
+					(_req: unknown, meta: Metadata, _opts: unknown, cb: (...args: unknown[]) => void) => {
+						expect(meta.get("authorization")).toEqual(["Bearer refreshed-token"]);
+						cb(null, {
+							value: { fieldPath: "a", value: { stringValue: "v" }, checksum: "c" },
+						});
+					},
+				);
+
+				await tokenClient.get("tenant-1", "a");
+				tokenClient.close();
+			});
+		});
 	});
 
 	describe("AbortSignal", () => {


### PR DESCRIPTION
## Summary

- Tokens set at construction time were frozen — clients in long-running processes could not refresh expiring JWTs without creating a new client and tearing down watchers.
- `setToken(token)` mutates the shared `Metadata` object in place, so active `ConfigWatcher` instances automatically use the new token on their next reconnect with no extra wiring.
- When called on a header-mode client (x-subject / x-role), it clears those keys and switches fully to JWT auth for all subsequent RPCs.

## Test plan

- [x] `setToken()` on a header-mode client: subsequent `get()` sends `Bearer <new-token>` and clears `x-subject` / `x-role`
- [x] `setToken()` on a token-mode client: subsequent `get()` sends the rotated token
- [x] All 225 existing unit + contract tests pass

Closes #62