### PR TITLE
Drop Node 20 support (EOL April 2026)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # CI pipeline for the OpenDecree TypeScript SDK.
 #
-# Jobs: lint, typecheck, test (matrix: Node 20/22/24), examples, integration → check (alls-green gate)
+# Jobs: lint, typecheck, test (matrix: Node 22/24), examples, integration → check (alls-green gate)
 # The check job aggregates all results for branch protection.
 #
 # The first job defines YAML anchors (&checkout, &setup-node-22, &install)
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20", "22", "24"]
+        node-version: ["22", "24"]
     steps:
       - *checkout
       - name: Set up Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-
 
 ## Requirements
 
-- Node.js **≥ 20** (ESM-only package — CommonJS is not supported)
+- Node.js **≥ 22** (ESM-only package — CommonJS is not supported)
 
 ## Install
 
@@ -105,7 +105,7 @@ Runnable examples in the [`examples/`](examples/) directory:
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 22+
 - A running OpenDecree server (v0.8.0 – v0.x, pre-1.0)
 
 ## Questions?

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/opendecree/decree-typescript/issues"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.12.0"


### PR DESCRIPTION
## Summary

- Node 20 reached end-of-life in April 2026; continuing to test against it provides no signal and may block upgrades.
- Bumps `engines.node` to `>=22` and removes Node 20 from the CI test matrix.

## Test plan

- [ ] CI passes on Node 22 and Node 24
- [ ] `package.json` `engines.node` reflects `>=22`
- [ ] README requirements sections updated to Node 22+

Closes #65