### PR TITLE
feat(linter): enable useAwait and noFloatingPromises biome rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,16 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"suspicious": {
+				"useAwait": "error"
+			},
+			"nursery": {
+				"noFloatingPromises": "error"
+			}
 		}
 	},
 	"formatter": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -222,7 +222,7 @@ export class ConfigClient {
 	 *
 	 * @returns A record mapping field paths to their string values.
 	 */
-	async getAll(
+	getAll(
 		tenantId: string,
 		options?: { timeout?: number; signal?: AbortSignal },
 	): Promise<Record<string, string>> {
@@ -250,7 +250,7 @@ export class ConfigClient {
 	 * coerces it to the schema-defined type. For type-safe writes, prefer
 	 * setNumber(), setBool(), setTime(), or setDuration().
 	 */
-	async set(
+	set(
 		tenantId: string,
 		fieldPath: string,
 		value: string,
@@ -281,7 +281,7 @@ export class ConfigClient {
 	}
 
 	/** Set a numeric config value. Sends the native number as a proto numberValue. */
-	async setNumber(
+	setNumber(
 		tenantId: string,
 		fieldPath: string,
 		value: number,
@@ -296,7 +296,7 @@ export class ConfigClient {
 	}
 
 	/** Set a boolean config value. Sends the native boolean as a proto boolValue. */
-	async setBool(
+	setBool(
 		tenantId: string,
 		fieldPath: string,
 		value: boolean,
@@ -311,7 +311,7 @@ export class ConfigClient {
 	}
 
 	/** Set a timestamp config value. Sends the Date as a proto timeValue. */
-	async setTime(
+	setTime(
 		tenantId: string,
 		fieldPath: string,
 		value: Date,
@@ -329,7 +329,7 @@ export class ConfigClient {
 	 * Set a duration config value. The value must be a duration string
 	 * (e.g. "1h30m", "300s") — the server parses and validates the format.
 	 */
-	async setDuration(
+	setDuration(
 		tenantId: string,
 		fieldPath: string,
 		value: string,
@@ -350,7 +350,7 @@ export class ConfigClient {
 	 * @param options - Optional description for the audit log, idempotency key for safe DEADLINE_EXCEEDED retries,
 	 *   and per-field expected checksums for optimistic concurrency control.
 	 */
-	async setMany(
+	setMany(
 		tenantId: string,
 		values: Record<string, SetValue>,
 		options?: {
@@ -383,7 +383,7 @@ export class ConfigClient {
 	/**
 	 * Set a config field to null.
 	 */
-	async setNull(
+	setNull(
 		tenantId: string,
 		fieldPath: string,
 		options?: {
@@ -462,13 +462,14 @@ export class ConfigClient {
 	/**
 	 * Async dispose pattern support — use with `await using`.
 	 */
-	async [Symbol.asyncDispose](): Promise<void> {
+	[Symbol.asyncDispose](): Promise<void> {
 		this.close();
+		return Promise.resolve();
 	}
 
 	// --- Private helpers ---
 
-	private async setTyped(
+	private setTyped(
 		tenantId: string,
 		fieldPath: string,
 		value: SetValue,

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -389,9 +389,9 @@ export class ConfigWatcher extends EventEmitter {
 	 * Safe to call multiple times. After stopping, registered WatchedField
 	 * async iterators will complete.
 	 */
-	async stop(): Promise<void> {
+	stop(): Promise<void> {
 		if (this.stopped) {
-			return;
+			return Promise.resolve();
 		}
 		this.stopped = true;
 
@@ -408,6 +408,7 @@ export class ConfigWatcher extends EventEmitter {
 		for (const field of this.fields.values()) {
 			field._stop();
 		}
+		return Promise.resolve();
 	}
 
 	/**

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -645,6 +645,7 @@ describe("ConfigClient", () => {
 		});
 
 		it("works with await using", async () => {
+			// biome-ignore lint/suspicious/useAwait: await using satisfies the await requirement but biome doesn't recognise it yet
 			await (async () => {
 				await using c = client;
 				void c;

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -502,6 +502,7 @@ describe("ConfigWatcher", () => {
 			watcher.field("payments.fee", Number, { default: 0.01 });
 			await watcher.start();
 
+			// biome-ignore lint/suspicious/useAwait: await using satisfies the await requirement but biome doesn't recognise it yet
 			await (async () => {
 				await using w = watcher;
 				void w;


### PR DESCRIPTION
## Summary

- Enables two Biome lint rules (`suspicious/useAwait` and `nursery/noFloatingPromises`) to enforce correct async/Promise handling across the SDK.
- Removes unnecessary `async` modifiers from 11 methods in `ConfigClient` and `ConfigWatcher` that delegated directly to Promise-returning helpers without awaiting.
- `asyncDispose` and `stop` now explicitly return `Promise.resolve()` to satisfy their `Promise<void>` signatures without the async wrapper.

## Test plan

- [x] `npx biome check src/` passes with zero diagnostics under the new rules
- [x] `npx tsc --noEmit` reports no type errors
- [x] `npm test` — all 225 tests pass

Closes #66