### PR TITLE
fix(compat): resolve cyclic import between compat.ts and index.ts

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -5,7 +5,7 @@
  */
 
 import { IncompatibleServerError } from "./errors.js";
-import { SUPPORTED_SERVER_VERSION } from "./index.js";
+import { SUPPORTED_SERVER_VERSION } from "./version.js";
 
 /**
  * Parse a semver-like version string into an array of numbers.


### PR DESCRIPTION
## Summary

- `compat.ts` imported `SUPPORTED_SERVER_VERSION` from `index.ts`, creating a cycle since `index.ts` re-exports from `client.ts` which may itself import from `compat.ts`.
- `version.ts` is already the canonical source for this constant — `index.ts` just re-exports it.
- Pointing `compat.ts` directly at `version.ts` breaks the cycle with a one-line change.

## Test plan

- [x] `npm run build` — compiles cleanly with no errors
- [x] `npm test` — all 225 tests pass

Closes #67