### PR TITLE
build: gate prepublishOnly on lint, typecheck, and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "DECREE_INTEGRATION=1 sh -c 'cd integration && vitest run'",
     "pre-commit": "biome check src/ test/ integration/ && tsc --noEmit && vitest run",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run pre-commit && npm run build"
   },
   "keywords": [
     "config",


### PR DESCRIPTION
## Summary

- Prevents publishing a broken package by running lint, typecheck, and unit tests before the build step.
- `prepublishOnly` now chains `npm run pre-commit` (biome + tsc --noEmit + vitest) ahead of `npm run build`.

## Test plan

- [ ] Confirm `npm publish` (dry-run) runs biome check, tsc, and vitest before building.
- [ ] Introduce a lint error, verify `npm publish` aborts before the build.

Closes #69