### PR TITLE
docs: showcase await using pattern in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,41 +24,57 @@ npm install @opendecree/sdk
 
 ## Quick Start
 
+The SDK implements `Symbol.dispose` / `Symbol.asyncDispose`, so you can use TypeScript 5.2's `using` statement for automatic cleanup — no try/finally needed.
+
 ```typescript
 import { ConfigClient } from '@opendecree/sdk';
 
+// `using` closes the gRPC channel automatically when the block exits
+await using client = new ConfigClient('localhost:9090', { subject: 'myapp' });
+
+// Get config values (default: string)
+const fee = await client.get('tenant-id', 'payments.fee');
+
+// Typed gets via runtime converters
+const retries = await client.get('tenant-id', 'payments.retries', Number);
+const enabled = await client.get('tenant-id', 'payments.enabled', Boolean);
+
+// Nullable gets
+const optional = await client.get('tenant-id', 'payments.fee', Number, { nullable: true });
+
+// Set values
+await client.set('tenant-id', 'payments.fee', '0.5%');
+
+// Set multiple values atomically
+await client.setMany('tenant-id', {
+  'payments.fee': '0.5%',
+  'payments.retries': '3',
+});
+```
+
+<details>
+<summary>Prefer try/finally?</summary>
+
+```typescript
 const client = new ConfigClient('localhost:9090', { subject: 'myapp' });
 try {
-  // Get config values (default: string)
   const fee = await client.get('tenant-id', 'payments.fee');
-
-  // Typed gets via runtime converters
-  const retries = await client.get('tenant-id', 'payments.retries', Number);
-  const enabled = await client.get('tenant-id', 'payments.enabled', Boolean);
-
-  // Nullable gets
-  const optional = await client.get('tenant-id', 'payments.fee', Number, { nullable: true });
-
-  // Set values
-  await client.set('tenant-id', 'payments.fee', '0.5%');
-
-  // Set multiple values atomically
-  await client.setMany('tenant-id', {
-    'payments.fee': '0.5%',
-    'payments.retries': '3',
-  });
+  // ...
 } finally {
   client.close();
 }
 ```
+</details>
 
 ## Watch for Changes
+
+`ConfigWatcher` also supports `await using` for automatic stop + close:
 
 ```typescript
 import { ConfigClient } from '@opendecree/sdk';
 
-const client = new ConfigClient('localhost:9090', { subject: 'myapp' });
-const watcher = client.watch('tenant-id');
+await using client = new ConfigClient('localhost:9090', { subject: 'myapp' });
+await using watcher = client.watch('tenant-id');
 
 // Register fields before starting
 const fee = watcher.field('payments.fee', Number, { default: 0.01 });
@@ -80,10 +96,7 @@ fee.on('change', (oldVal, newVal) => {
 for await (const change of fee) {
   console.log(change.fieldPath, change.newValue);
 }
-
-// Cleanup
-await watcher.stop();
-client.close();
+// watcher.stop() + client.close() called automatically
 ```
 
 ## Examples
@@ -92,7 +105,7 @@ Runnable examples in the [`examples/`](examples/) directory:
 
 | Example | What it shows |
 |---------|--------------|
-| [quickstart](examples/quickstart/) | Type converters (`Number`, `Boolean`), try/finally |
+| [quickstart](examples/quickstart/) | `using` / `await using`, type converters (`Number`, `Boolean`) |
 | [live-config](examples/live-config/) | `ConfigWatcher`, `.on('change')`, `for await...of` |
 | [nextjs-integration](examples/nextjs-integration/) | Singleton watcher for server-side config |
 | [error-handling](examples/error-handling/) | `RetryConfig`, `{ nullable: true }`, `instanceof` narrowing |

--- a/examples/quickstart/main.ts
+++ b/examples/quickstart/main.ts
@@ -13,33 +13,31 @@ import { ConfigClient } from "@opendecree/sdk";
 import { getTenantId } from "../shared.js";
 
 async function main(): Promise<void> {
-  const tenantId = getTenantId();
-  const client = new ConfigClient("localhost:9090", { subject: "quickstart-example" });
+	const tenantId = getTenantId();
 
-  try {
-    // get() returns string by default.
-    const name = await client.get(tenantId, "app.name");
-    console.log(`app.name:          ${name}`);
+	// `await using` calls [Symbol.asyncDispose] automatically — no try/finally needed.
+	await using client = new ConfigClient("localhost:9090", { subject: "quickstart-example" });
 
-    // Pass a type converter for typed values.
-    const debug = await client.get(tenantId, "app.debug", Boolean);
-    console.log(`app.debug:         ${debug}`);
+	// get() returns string by default.
+	const name = await client.get(tenantId, "app.name");
+	console.log(`app.name:          ${name}`);
 
-    const rateLimit = await client.get(tenantId, "server.rate_limit", Number);
-    console.log(`server.rate_limit: ${rateLimit}`);
+	// Pass a type converter for typed values.
+	const debug = await client.get(tenantId, "app.debug", Boolean);
+	console.log(`app.debug:         ${debug}`);
 
-    const feeRate = await client.get(tenantId, "payments.fee_rate", Number);
-    console.log(`payments.fee_rate: ${feeRate}`);
+	const rateLimit = await client.get(tenantId, "server.rate_limit", Number);
+	console.log(`server.rate_limit: ${rateLimit}`);
 
-    // set() and setMany() for writes.
-    await client.set(tenantId, "app.debug", "true");
-    console.log("\nSet app.debug = true");
+	const feeRate = await client.get(tenantId, "payments.fee_rate", Number);
+	console.log(`payments.fee_rate: ${feeRate}`);
 
-    const updated = await client.get(tenantId, "app.debug", Boolean);
-    console.log(`app.debug:         ${updated}`);
-  } finally {
-    client.close();
-  }
+	// set() and setMany() for writes.
+	await client.set(tenantId, "app.debug", "true");
+	console.log("\nSet app.debug = true");
+
+	const updated = await client.get(tenantId, "app.debug", Boolean);
+	console.log(`app.debug:         ${updated}`);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Summary

- Promotes `await using` as the primary resource-management pattern in the README, since `ConfigClient` and `ConfigWatcher` both implement `Symbol.asyncDispose` — readers should see the flagship TS 5.2 feature front and center, not buried or absent.
- Moves the try/finally approach into a collapsible `<details>` block so it remains discoverable without competing with `await using`.
- Updates `examples/quickstart/main.ts` to match — the runnable example now demonstrates `await using` instead of try/finally.

## Test plan

- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Lint passes (`npm run lint`)
- [ ] README renders correctly in GitHub preview (no broken markdown, `<details>` block collapses)

Closes #68