### PR TITLE
ci: fix integration Docker build cache (write back to registry)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      packages: read
+      packages: write
     steps:
       - *checkout
       - *setup-node-22
@@ -142,7 +142,7 @@ jobs:
           load: true
           tags: decree-tools
           cache-from: type=registry,ref=ghcr.io/opendecree/decree-tools:buildcache
-          cache-to: type=local,dest=/tmp/.buildx-cache-tools,mode=max
+          cache-to: type=registry,ref=ghcr.io/opendecree/decree-tools:buildcache,mode=max
 
       - name: Build server image
         uses: docker/build-push-action@v7
@@ -152,7 +152,7 @@ jobs:
           load: true
           tags: decree-server
           cache-from: type=registry,ref=ghcr.io/opendecree/decree:buildcache
-          cache-to: type=local,dest=/tmp/.buildx-cache-server,mode=max
+          cache-to: type=registry,ref=ghcr.io/opendecree/decree:buildcache,mode=max
 
       - name: Start decree stack
         run: docker compose up -d --wait service

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      packages: write
+      packages: read
     steps:
       - *checkout
       - *setup-node-22
@@ -141,8 +141,8 @@ jobs:
           file: _decree/build/Dockerfile.tools
           load: true
           tags: decree-tools
-          cache-from: type=registry,ref=ghcr.io/opendecree/decree-tools:buildcache
-          cache-to: type=registry,ref=ghcr.io/opendecree/decree-tools:buildcache,mode=max
+          cache-from: type=gha,scope=decree-tools
+          cache-to: type=gha,scope=decree-tools,mode=max
 
       - name: Build server image
         uses: docker/build-push-action@v7
@@ -151,8 +151,8 @@ jobs:
           file: _decree/build/Dockerfile
           load: true
           tags: decree-server
-          cache-from: type=registry,ref=ghcr.io/opendecree/decree:buildcache
-          cache-to: type=registry,ref=ghcr.io/opendecree/decree:buildcache,mode=max
+          cache-from: type=gha,scope=decree-server
+          cache-to: type=gha,scope=decree-server,mode=max
 
       - name: Start decree stack
         run: docker compose up -d --wait service


### PR DESCRIPTION
## Summary

- The integration job was reading Docker layer cache from ghcr.io but writing it to a local runner path that is discarded when the job ends — so the cache was effectively never warm and every run rebuilt both images from scratch.
- Switching \`cache-to\` to \`type=registry\` (same refs as \`cache-from\`) closes the write-back loop: the first run seeds the cache, subsequent runs hit it.
- \`packages: write\` added to the job permissions so the \`GITHUB_TOKEN\` can push the cache manifest to ghcr.io.

## Test plan

- [ ] Verify the integration job succeeds on this PR (first run seeds the cache)
- [ ] Trigger a second run (re-push or re-run) and confirm "Build tools image" and "Build server image" steps show cache HIT logs from Buildx, reducing build time significantly