### PR TITLE
ci: skip pipeline for docs-only PRs via paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 # Jobs: lint, typecheck, test (matrix: Node 22/24), examples, integration → check (alls-green gate)
 # The check job aggregates all results for branch protection.
 #
+# Docs-only PRs (*.md, docs/**, examples/**/README.md) skip the entire workflow via
+# paths-ignore; GitHub marks the required status checks as passing automatically.
+#
 # The first job defines YAML anchors (&checkout, &setup-node-22, &install)
 # on its setup steps; subsequent jobs alias them to avoid repetition.
 # The test job uses its own setup-node step because the matrix node-version
@@ -19,6 +22,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "examples/**/README.md"
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Summary

- Docs-only PRs (any `*.md`, `docs/**`, `examples/**/README.md`) waste 10–15 minutes of CI running the full integration stack against changes that cannot affect runtime behavior.
- Adding `paths-ignore` to the `pull_request` trigger causes GitHub to skip the entire workflow and automatically mark the required status checks as passing.
- PRs that touch both docs and source still run the full pipeline.

## Test plan

- [ ] Verify a docs-only PR (README edit) shows all CI checks as skipped/passing without running any jobs
- [ ] Verify a mixed PR (README + source edit) triggers the full pipeline

Closes #105