### PR TITLE
feat: add GitHub release on tag push, backfill existing releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,3 +41,39 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
       - run: npm publish --provenance --access public --tag ${{ steps.tag.outputs.tag }}
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.14"
+      - run: npm ci
+      - run: npm run build
+      - name: Create tarball
+        run: |
+          VERSION="${{ github.ref_name }}"
+          tar -czf "decree-typescript-${VERSION}.tar.gz" dist/
+      - name: Determine if prerelease
+        id: prerelease
+        run: |
+          VERSION="${{ github.ref_name }}"
+          if echo "$VERSION" | grep -qE 'alpha|beta|rc'; then
+            echo "flag=--prerelease" >> $GITHUB_OUTPUT
+          else
+            echo "flag=" >> $GITHUB_OUTPUT
+          fi
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          gh release create "$TAG" \
+            "decree-typescript-${TAG}.tar.gz" \
+            --generate-notes \
+            --title "Release ${TAG}" \
+            ${{ steps.prerelease.outputs.flag }}


### PR DESCRIPTION
## Summary

- Backfilled GitHub Releases for all 5 existing version tags (v0.1.0, v0.2.0-alpha.1, v0.2.0, v0.3.0-alpha.1, v0.3.0) using `--generate-notes`; alpha tags marked as pre-releases
- Added a `release` job to `publish.yml` that runs after `publish` succeeds on tag push
- The job builds `dist/`, packages it as `decree-typescript-<tag>.tar.gz`, and creates a GitHub release with auto-generated notes
- Alpha/beta/rc tags are automatically flagged as pre-releases

## Test plan

- [ ] Verify all 5 backfilled releases appear at https://github.com/opendecree/decree-typescript/releases
- [ ] On next tag push (`v*.*.*`), confirm the `release` job runs after `publish` and creates a release with the tarball artifact
- [ ] Confirm alpha/rc tags produce a pre-release entry

Closes #9