### PR TITLE
feat: add devcontainer for Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "OpenDecree TypeScript SDK",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "npm ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "biomejs.biome",
+        "ms-vscode.vscode-typescript-next"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "biomejs.biome",
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "forwardPorts": []
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![License](https://img.shields.io/github/license/opendecree/decree-typescript)](LICENSE)
 [![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![codecov](https://codecov.io/gh/opendecree/decree-typescript/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-typescript)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-typescript)
 
 TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-driven configuration management.
 


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` using the official Node 22 dev container image (`mcr.microsoft.com/devcontainers/javascript-node:22`)
- Post-create command runs `npm ci` so the environment is ready immediately after container creation
- Configures VS Code with Biome extension (default formatter, format-on-save) and TypeScript Next extension
- Adds 'Open in GitHub Codespaces' badge to README

## Test plan

- [ ] Click the Codespaces badge in README — should open a new Codespace for the repo
- [ ] Verify `npm ci` runs automatically after container creation
- [ ] Verify Biome is active as the default formatter in VS Code
- [ ] Verify format-on-save works in the Codespace

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)