### PR TITLE
docs: fix server range and write-retry claims in examples

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,14 +198,26 @@ Use `checkCompatibility()` to verify explicitly:
 ```typescript
 const client = new ConfigClient('localhost:9090');
 await client.checkCompatibility();
-// Throws IncompatibleServerError if server version is outside >=0.3.0,<1.0.0
+// Throws IncompatibleServerError if server version is outside >=0.8.0,<1.0.0
 ```
 
-The server version is fetched once and cached for the lifetime of the client:
+The server info is fetched once and cached for the lifetime of the client:
 
 ```typescript
-const version = await client.serverVersion;
-console.log(version); // { version: "0.3.1", commit: "abc123" }
+const info = await client.serverInfo;
+console.log(info);
+// {
+//   version: "0.8.1",
+//   commit: "abc123",
+//   features: {
+//     schema: true,
+//     config: true,
+//     audit: true,
+//     usage_tracking: false,
+//     jwt_auth: false,
+//     http_gateway: true,
+//   },
+// }
 ```
 
 ## Error Types

--- a/examples/error-handling/main.ts
+++ b/examples/error-handling/main.ts
@@ -84,7 +84,12 @@ async function main(): Promise<void> {
     // --- Retry behavior ---
     console.log("\n=== Retry ===");
     console.log("Configured: 5 attempts, 200ms initial backoff, 10s max backoff");
-    console.log("Retries are automatic on UNAVAILABLE and DEADLINE_EXCEEDED.");
+    // Reads (get, getAll) retry on UNAVAILABLE, DEADLINE_EXCEEDED, and RESOURCE_EXHAUSTED.
+    // Writes (set, setMany, setNull) retry only on UNAVAILABLE by default, since the server
+    // may have already applied the write. Passing an idempotencyKey additionally enables
+    // DEADLINE_EXCEEDED retries for that write.
+    console.log("Reads retry on UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED.");
+    console.log("Writes retry only on UNAVAILABLE (pass idempotencyKey to also retry DEADLINE_EXCEEDED).");
 
     // To disable retry entirely, pass retry: false.
     const noRetryClient = new ConfigClient("localhost:9090", {


### PR DESCRIPTION
## Summary

- The documented supported-server range and the error-handling retry guidance were both factually wrong. The retry misstatement was a data-safety hazard: it implied writes retry on `DEADLINE_EXCEEDED` by default, when in fact writes retry only on `UNAVAILABLE` unless an `idempotencyKey` is set.
- The server-info doc example used the deprecated `serverVersion` getter and omitted the `features` map, steering users toward an API that is being removed.

## Changes

- `docs/configuration.md`: corrected supported server range to `>=0.8.0,<1.0.0`; switched the server-info example to `serverInfo` with a 0.8.x version and the `features` map.
- `examples/error-handling/main.ts`: reworded retry guidance to match `src/retry.ts` — reads retry on `UNAVAILABLE`/`DEADLINE_EXCEEDED`/`RESOURCE_EXHAUSTED`; writes retry only on `UNAVAILABLE` unless `idempotencyKey` is set (which additionally enables `DEADLINE_EXCEEDED`).

## Test plan

- `npm run build` and `npx tsc --noEmit` pass.
- Example typecheck (`cd examples && npm ci && npx tsc --noEmit`) passes — the authoritative CI gate for the edited example.
- `npm run lint` and full `npm test` (255 tests) pass.
- Each corrected fact verified against source: `src/version.ts`, `src/retry.ts`, `src/types.ts`, `src/client.ts`.

Closes #124