### PR TITLE
docs: trim README badges to highest-signal set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![npm](https://img.shields.io/npm/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![License](https://img.shields.io/github/license/opendecree/decree-typescript)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-opendecree.github.io-teal)](https://opendecree.github.io/decree-typescript)
+[![codecov](https://codecov.io/gh/opendecree/decree-typescript/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-typescript)
+
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-typescript)
 
 TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-driven configuration management.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,8 @@
 
 [![CI](https://github.com/opendecree/decree-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/opendecree/decree-typescript/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
-[![Node](https://img.shields.io/node/v/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
-[![Downloads](https://img.shields.io/npm/dm/@opendecree/sdk)](https://www.npmjs.com/package/@opendecree/sdk)
 [![License](https://img.shields.io/github/license/opendecree/decree-typescript)](LICENSE)
-[![Project Status: WIP](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-[![codecov](https://codecov.io/gh/opendecree/decree-typescript/graph/badge.svg)](https://codecov.io/gh/opendecree/decree-typescript)
+[![Docs](https://img.shields.io/badge/docs-opendecree.github.io-teal)](https://opendecree.github.io/decree-typescript)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/opendecree/decree-typescript)
 
 TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-driven configuration management.


### PR DESCRIPTION
## Summary
- Reduce header badges to the 5 highest-signal: CI, npm, License, Docs, Codespaces.
- Drop Node-version, Downloads, repostatus "WIP", and codecov badges (Downloads is at zero pre-1.0; Alpha note already covers status).
- Add a Docs badge linking to the GitHub Pages site, mirroring the Python SDK README.

## Test plan
- [x] Visual check of remaining badge markup renders correctly