### PR TITLE
docs: collapse duplicate Requirements section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ TypeScript SDK for [OpenDecree](https://github.com/opendecree/decree) -- schema-
 ## Requirements
 
 - Node.js **≥ 22** (ESM-only package — CommonJS is not supported)
+- A running OpenDecree server (v0.8.0 – v0.x, pre-1.0)
 
 ## Install
 
@@ -116,11 +117,6 @@ Runnable examples in the [`examples/`](examples/) directory:
 - [Quick Start](docs/quickstart.md) -- install, first get/set, typed gets, error handling
 - [Configuration](docs/configuration.md) -- all client options, auth, TLS, retry, timeouts
 - [Watching](docs/watching.md) -- ConfigWatcher, WatchedField, EventEmitter, async iteration
-
-## Requirements
-
-- Node.js 22+
-- A running OpenDecree server (v0.8.0 – v0.x, pre-1.0)
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

- The README stated the Node.js 22+ requirement twice — a top-level **Requirements** section and a second one before **Questions?**. Collapsed to the single top-level block.
- The supported server line (`v0.8.0 – v0.x, pre-1.0`) now lives in that one block. The TS floor (`SUPPORTED_SERVER_VERSION = >=0.8.0,<1.0.0`) is already correct, so no code change — this is the source of truth the Python SDK was realigned to.

## Test plan

- [x] Verified a single `## Requirements` heading remains, listing both Node and server requirements
- [x] Markdown-only change; no code, tests, or generated files touched

Refs opendecree/decree#906