### PR TITLE
chore(deps): ignore typescript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # typedoc@0.28 peer dep caps at typescript 6.0.x; only TS7 support is a 1.0.0-dev preview
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- Dependabot PR #148 bumped `typescript` to 7.0.2, which conflicts with `typedoc@0.28.20`'s peer dependency (`typescript@5.0.x || ... || 6.0.x`), breaking `npm ci` with an ERESOLVE error.
- `typedoc` has no stable release compatible with TypeScript 7 yet — only a `1.0.0-dev.x` preview series.
- Ignore major-version bumps to `typescript` in Dependabot config until `typedoc` ships a stable TS7-compatible release.

## Test plan
- [x] Confirmed the ERESOLVE failure in PR #148's CI logs (typedoc peer dep conflict)
- [x] Confirmed no stable typedoc release supports TypeScript 7 (`npm view typedoc versions`)
- [x] Closed PR #148 with explanation