### PR TITLE
ci(stale): exempt milestoned issues, stop auto-closing issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,12 @@
 name: Stale issues and PRs
 
-# Daily sweep: marks inactive issues/PRs as stale and eventually closes
-# them. The `keep` label opts an item out entirely; `good first issue`
-# and `bug` are also exempt for issues. opendecree/decree#162.
+# Daily sweep. Issues are marked stale for visibility but are never closed
+# automatically — on this project the issue tracker doubles as the roadmap,
+# and a parked item is not an abandoned one. Pull requests still auto-close,
+# since a stale PR is genuinely abandoned work.
+#
+# Issue exemptions: anything with a milestone, plus the `keep`,
+# `good first issue`, and `bug` labels. opendecree/decree#162, opendecree/decree#1028.
 #
 # Tuning happens here per-repo so each project can adjust independently
 # if traffic patterns diverge.
@@ -25,23 +29,22 @@ jobs:
         with:
           stale-issue-message: >
             This issue has been inactive for 60 days and is being marked
-            stale. It will be closed in 14 days unless there is new
-            activity. Add the `keep` label to opt out of future sweeps.
+            stale. It will not be closed automatically — comment, or remove
+            the `stale` label, if it is still relevant. Add the `keep` label
+            to opt out of future sweeps.
           stale-pr-message: >
             This PR has been inactive for 30 days and is being marked
             stale. It will be closed in 7 days unless there is new
             activity. Add the `keep` label to opt out of future sweeps.
-          close-issue-message: >
-            Closing for inactivity. Reopen if this is still relevant.
           close-pr-message: >
             Closing for inactivity. Reopen if this is still relevant.
           stale-issue-label: stale
           stale-pr-label: stale
           days-before-issue-stale: 60
-          days-before-issue-close: 14
+          days-before-issue-close: -1  # never auto-close issues
           days-before-pr-stale: 30
           days-before-pr-close: 7
+          exempt-all-issue-milestones: true
           exempt-issue-labels: 'keep,good first issue,bug'
           exempt-pr-labels: 'keep'
-          close-issue-reason: not_planned
           operations-per-run: 100


### PR DESCRIPTION
## Summary

- The daily stale sweep closed 20 issues as `not_planned` on 2026-07-12 across `decree`, `decree-ui`, and `demos` — including every item in the ROADMAP "Planned" row and all six milestoned `demos` issues.
- The affected milestones now read 100% complete, but only because the bot closed the remainder. The work did not ship.
- On this project the issue tracker doubles as the roadmap, so the sweep should surface staleness without acting on it. Issues are now marked but never auto-closed, and any milestoned issue is exempt outright.
- Pull requests keep the existing 30/7 auto-close, since a stale PR is genuinely abandoned work in a way a parked issue is not.

## Test plan

- [x] Workflow parses as valid YAML
- [x] Parsed config confirms `days-before-issue-close: -1` and `exempt-all-issue-milestones: true`
- [x] PR sweep values unchanged (30-day stale, 7-day close)
- [x] Dead config removed (`close-issue-message`, `close-issue-reason`) now that issues never close
- [ ] Verify the next scheduled run marks stale without closing

Refs opendecree/decree#1028
